### PR TITLE
feat: expand topic modeling with multiple algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # speech_cc
-speech_cc
+
+Prueba de concepto para clasificación y descubrimiento de tópicos en conversaciones.
+
+## Contenido
+- `topic_modeling.ipynb`: genera datos sintéticos con mensajes internos y externos, aplica clasificación supervisada y múltiples modelos no supervisados (LDA, NMF, K-Means, BERTopic) para encontrar nuevos tópicos.

--- a/topic_modeling.ipynb
+++ b/topic_modeling.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clasificación y descubrimiento de tópicos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fase 1: Datos sintéticos\nGeneramos conversaciones con intervenciones internas y externas. El 70% de los mensajes del cliente (externo) tienen tópicos conocidos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "data = [\n",
+    "    {\"speaker\": \"interno\", \"text\": \"Hola, ¿en qué puedo ayudarte?\", \"topics\": []},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"¿Cuál es el precio del plan básico?\", \"topics\": [\"precio\"]},\n",
+    "    {\"speaker\": \"interno\", \"text\": \"El plan básico cuesta 10 dólares.\", \"topics\": []},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Gracias, ¿y si quiero soporte premium?\", \"topics\": [\"soporte\", \"precio\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"El servicio fue muy malo\", \"topics\": [\"reclamo\"]},\n",
+    "    {\"speaker\": \"interno\", \"text\": \"Lamentamos escuchar eso, mejoraremos.\", \"topics\": []},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Quiero saber la factura pendiente\", \"topics\": [\"facturacion\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Necesito hablar con ventas\", \"topics\": [\"ventas\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"¿Cuál es el más económico?\", \"topics\": [\"ventas\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Sí, pero sigue igual\", \"topics\": None},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"¿Me pueden ayudar?\", \"topics\": None},\n",
+    "]\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "df"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fase 2: Clasificación supervisada de tópicos conocidos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.preprocessing import MultiLabelBinarizer\n",
+    "from sklearn.multiclass import OneVsRestClassifier\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.metrics import classification_report\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "\n",
+    "client_msgs = df[df['speaker'] == 'externo'].copy()\n",
+    "labeled = client_msgs[client_msgs['topics'].notnull()]\n",
+    "unlabeled = client_msgs[client_msgs['topics'].isnull()]\n",
+    "\n",
+    "mlb = MultiLabelBinarizer()\n",
+    "y = mlb.fit_transform(labeled['topics'])\n",
+    "\n",
+    "pipeline = Pipeline([\n",
+    "    ('tfidf', TfidfVectorizer()),\n",
+    "    ('clf', OneVsRestClassifier(LogisticRegression(solver='liblinear')))\n",
+    "])\n",
+    "\n",
+    "scores = cross_val_score(pipeline, labeled['text'], y, cv=3, scoring='f1_macro')\n",
+    "print('F1 promedio CV:', scores.mean())\n",
+    "\n",
+    "pipeline.fit(labeled['text'], y)\n",
+    "y_pred = pipeline.predict(labeled['text'])\n",
+    "print(classification_report(y, y_pred, target_names=mlb.classes_))\n",
+    "\n",
+    "pred = pipeline.predict(unlabeled['text'])\n",
+    "unlabeled['topics'] = mlb.inverse_transform(pred)\n",
+    "\n",
+    "client_msgs = pd.concat([labeled, unlabeled])\n",
+    "client_msgs"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fase 3: Descubrimiento de tópicos con modelos no supervisados"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LDA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "from sklearn.decomposition import LatentDirichletAllocation\n",
+    "\n",
+    "cv = CountVectorizer(stop_words='spanish')\n",
+    "X_cv = cv.fit_transform(client_msgs['text'])\n",
+    "lda = LatentDirichletAllocation(n_components=5, random_state=0)\n",
+    "lda.fit(X_cv)\n",
+    "\n",
+    "def display_topics(model, feature_names, n_top_words=5):\n",
+    "    for idx, topic in enumerate(model.components_):\n",
+    "        terms = [feature_names[i] for i in topic.argsort()[:-n_top_words - 1:-1]]\n",
+    "        print(f'Tópico {idx}: {' '.join(terms)}')\n",
+    "\n",
+    "feature_names = cv.get_feature_names_out()\n",
+    "display_topics(lda, feature_names)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### NMF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.decomposition import NMF\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "\n",
+    "tfidf = TfidfVectorizer(stop_words='spanish')\n",
+    "X_tfidf = tfidf.fit_transform(client_msgs['text'])\n",
+    "nmf = NMF(n_components=5, random_state=0, init='nndsvda', max_iter=200)\n",
+    "nmf.fit(X_tfidf)\n",
+    "feature_names = tfidf.get_feature_names_out()\n",
+    "display_topics(nmf, feature_names)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clustering K-Means"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from sklearn.cluster import KMeans\n",
+    "\n",
+    "km = KMeans(n_clusters=5, random_state=0)\n",
+    "km.fit(X_tfidf)\n",
+    "order_centroids = km.cluster_centers_.argsort()[:, ::-1]\n",
+    "terms = tfidf.get_feature_names_out()\n",
+    "for i in range(5):\n",
+    "    top_terms = [terms[ind] for ind in order_centroids[i, :5]]\n",
+    "    print(f'Cluster {i}: {' '.join(top_terms)}')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### BERTopic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from bertopic import BERTopic\n",
+    "\n",
+    "bertopic_model = BERTopic(verbose=False)\n",
+    "ber_topics, _ = bertopic_model.fit_transform(client_msgs['text'].tolist())\n",
+    "bertopic_model.get_topic_info().head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fase 4: Distribución final de tópicos del cliente"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "all_topics = client_msgs['topics'].explode().dropna()\n",
+    "all_topics.value_counts()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- restructure notebook into phases for data, supervised classification, and unsupervised topic discovery
- add LDA, NMF, K-Means clustering, and BERTopic models to explore new topics
- document notebook usage and capabilities in README

## Testing
- `pytest`
- `python - <<'PY'\ntry:\n    import pandas, sklearn, bertopic\n    print('imports ok')\nexcept Exception as e:\n    print('import error:', e)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68aa619af2cc83288140381ff3b4fc76