### PR TITLE
Add example notebook for topic modeling

### DIFF
--- a/topic_modeling.ipynb
+++ b/topic_modeling.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demostración de clasificación y tópicos\n",
+    "\n",
+    "Ejemplo interactivo del flujo de `topic_modeling.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from topic_modeling import tokenize\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.preprocessing import MultiLabelBinarizer\n",
+    "from sklearn.multiclass import OneVsRestClassifier\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.decomposition import LatentDirichletAllocation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [\n",
+    "    {\"speaker\": \"interno\", \"text\": \"Hola, ¿en qué puedo ayudarte?\", \"topics\": []},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"¿Cuál es el precio del plan básico?\", \"topics\": [\"precio\"]},\n",
+    "    {\"speaker\": \"interno\", \"text\": \"El plan básico cuesta 10 dólares.\", \"topics\": []},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Gracias, ¿y si quiero soporte premium?\", \"topics\": [\"soporte\", \"precio\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"El servicio fue muy malo\", \"topics\": [\"reclamo\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Quiero saber la factura pendiente\", \"topics\": [\"facturacion\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"Necesito hablar con ventas\", \"topics\": [\"ventas\"]},\n",
+    "    {\"speaker\": \"externo\", \"text\": \"¿Cuál es el más económico?\", \"topics\": [\"ventas\"]}\n",
+    "]\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "client_msgs = df[df['speaker'] == 'externo']\n",
+    "mlb = MultiLabelBinarizer()\n",
+    "y = mlb.fit_transform(client_msgs['topics'])\n",
+    "\n",
+    "pipeline = Pipeline([\n",
+    "    ('tfidf', TfidfVectorizer(tokenizer=tokenize)),\n",
+    "    ('clf', OneVsRestClassifier(LogisticRegression(solver='liblinear')))\n",
+    "])\n",
+    "pipeline.fit(client_msgs['text'], y)\n",
+    "pipeline.predict(client_msgs['text'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cv = CountVectorizer(tokenizer=tokenize)\n",
+    "X = cv.fit_transform(client_msgs['text'])\n",
+    "lda = LatentDirichletAllocation(n_components=2, random_state=0)\n",
+    "lda.fit(X)\n",
+    "feature_names = cv.get_feature_names_out()\n",
+    "n_top_words = 5\n",
+    "for idx, topic in enumerate(lda.components_):\n",
+    "    terms = [feature_names[i] for i in topic.argsort()[:-n_top_words - 1:-1]]\n",
+    "    print('Tópico {}: {}'.format(idx, ' '.join(terms)))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a basic Jupyter notebook demonstrating the topic modeling workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa72b04b6083288b4000a88e0ed442