### PR TITLE
Add multilingual MiniLM embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ Prueba de concepto para clasificación y descubrimiento de tópicos en conversac
 
 ## Contenido
 - `topic_modeling.py`: genera datos sintéticos con mensajes internos y externos, aplica clasificación supervisada y múltiples modelos no supervisados (LDA, NMF, K-Means, BERTopic) para encontrar nuevos tópicos. Usa spaCy y NLTK con stopwords en español.
+- `embedding_model.py`: carga `paraphrase-multilingual-MiniLM-L12-v2` de `sentence-transformers` para obtener embeddings multilingües.
 - `nltk_data/`: stopwords de NLTK en inglés y español.
 - `requirements.txt`: dependencias del proyecto.

--- a/embedding_model.py
+++ b/embedding_model.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+
+_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+_model: SentenceTransformer | None = None
+
+
+def _get_model() -> SentenceTransformer:
+    """Lazily load and cache the SentenceTransformer model."""
+    global _model
+    if _model is None:
+        _model = SentenceTransformer(_MODEL_NAME)
+    return _model
+
+
+def embed_texts(texts: List[str]):
+    """Return embeddings for a list of texts using the sentence-transformers model.
+
+    Args:
+        texts: list of strings to encode.
+
+    Returns:
+        A 2D numpy array containing embeddings for each input text.
+    """
+    model = _get_model()
+    return model.encode(texts)
+
+
+if __name__ == "__main__":
+    sentences = [
+        "Hola mundo",
+        "Esto es un ejemplo",
+    ]
+    embeddings = embed_texts(sentences)
+    print(embeddings.shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn
 nltk
 spacy
 bertopic
+sentence-transformers

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from embedding_model import embed_texts
+
+
+def test_embeddings_shape():
+    texts = ["Hola", "Adios"]
+    try:
+        emb = embed_texts(texts)
+    except Exception as exc:  # pragma: no cover - network issues
+        pytest.skip(f"Model not available: {exc}")
+    assert emb.shape[0] == len(texts)


### PR DESCRIPTION
## Summary
- add `embedding_model.py` with lazy-loaded `paraphrase-multilingual-MiniLM-L12-v2` from sentence-transformers
- document embedding utility in README and include `sentence-transformers` dependency
- test embedding generation and skip when model unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa74915b3883288621173e6d1355d2