### PR TITLE
Load SentenceTransformer from local model directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .venv/
 __pycache__/
 *.zip
+
+model/*
+!model/.gitkeep

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@ Prueba de concepto para clasificación y descubrimiento de tópicos en conversac
 
 ## Requerimientos
 - Instalar las dependencias con `pip install -r requirements.txt`.
+- Descargar el modelo `paraphrase-multilingual-MiniLM-L12-v2` y colocarlo en la carpeta `model/` del proyecto. Ejemplo:
+
+  ```bash
+  git lfs install
+  git clone https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 \
+      model/paraphrase-multilingual-MiniLM-L12-v2
+  ```
+
+  Para trabajar sin conexión, establecer `TRANSFORMERS_OFFLINE=1` antes de ejecutar los scripts.
 
 ## Pruebas
 - Ejecutar `pytest` para validar el flujo supervisado y los modelos no supervisados.
 
 ## Contenido
 - `topic_modeling.py`: genera datos sintéticos con mensajes internos y externos, aplica clasificación supervisada y múltiples modelos no supervisados (LDA, NMF, K-Means, BERTopic) para encontrar nuevos tópicos. Usa spaCy y NLTK con stopwords en español.
-- `embedding_model.py`: carga `paraphrase-multilingual-MiniLM-L12-v2` de `sentence-transformers` para obtener embeddings multilingües.
+- `embedding_model.py`: carga `paraphrase-multilingual-MiniLM-L12-v2` desde `model/` usando `sentence-transformers` para obtener embeddings multilingües.
 - `nltk_data/`: stopwords de NLTK en inglés y español.
 - `requirements.txt`: dependencias del proyecto.

--- a/embedding_model.py
+++ b/embedding_model.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from typing import List
+from pathlib import Path
 
 from sentence_transformers import SentenceTransformer
 
-_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+# Path to the locally stored model inside the project.
+_MODEL_PATH = Path(__file__).resolve().parent / "model" / "paraphrase-multilingual-MiniLM-L12-v2"
 _model: SentenceTransformer | None = None
 
 
@@ -12,7 +14,7 @@ def _get_model() -> SentenceTransformer:
     """Lazily load and cache the SentenceTransformer model."""
     global _model
     if _model is None:
-        _model = SentenceTransformer(_MODEL_NAME)
+        _model = SentenceTransformer(str(_MODEL_PATH))
     return _model
 
 


### PR DESCRIPTION
## Summary
- Load `paraphrase-multilingual-MiniLM-L12-v2` from local `model/` path
- Document local model setup and offline usage
- Ignore model artifacts while tracking `model/` directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa76bd0dc8832881306ea64ba5e522